### PR TITLE
SPOI-9342 first cut with page for matured operator library

### DIFF
--- a/docs/create.md
+++ b/docs/create.md
@@ -1,7 +1,17 @@
 Creating Applications
 =====================
 
-Get started quickly by following the [Beginner's Guide](/beginner) and create your first Apache Apex application today!
+Here are a few links to get you started:
+
+- [Beginner's Guide](/beginner) An introductory guide that shows you how to generate a new
+  ready-to-run Apex application using the maven archetype and a good deal of the application
+  landscape at an introductory level.
+
+- [Operator Development](/operator_development)
+
+- [Operator Library](/library_operators)
+
+- [Demo Videos](/demo_videos)
 
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -106,6 +106,6 @@ DataTorrent RTS, built on Apache Apex, provides a high-performing, fault-toleran
   <a href="create" class="jumbotron-section">
     <img src="images/welcome/dt_toolbox.svg">
     <h2>Create Apps</h2>
-    <p>Tutorials and code samples to rapidly create DataTorrent applications using Java or dtAssemble.</p>
+    <p>Tutorials, operator library and code samples to rapidly create DataTorrent applications using Java or dtAssemble.</p>
   </a>
 </div>

--- a/docs/library_operators.md
+++ b/docs/library_operators.md
@@ -1,0 +1,40 @@
+Operator Library
+================
+
+The following operators, classified into three groups, are available:
+
+- Input
+    + Kafka Input [Guide](http://apex.apache.org/docs/malhar/operators/kafkaInputOperator/)
+      and [Java Doc](https://ci.apache.org/projects/apex-malhar/apex-malhar-javadoc-release-3.6/com/datatorrent/contrib/kafka/KafkaSinglePortStringInputOperator.html)
+    + HDFS Input [Guide](http://apex.apache.org/docs/malhar/operators/fsInputOperator/)
+      and [Java Doc](https://ci.apache.org/projects/apex-malhar/apex-malhar-javadoc-release-3.6/com/datatorrent/demos/wordcount/LineReader.html)
+    + HDFS Input for large files [Guide](http://apex.apache.org/docs/malhar/operators/file_splitter/)
+      and [Java Doc](https://ci.apache.org/projects/apex-malhar/apex-malhar-javadoc-release-3.6/com/datatorrent/lib/io/fs/FileSplitter.html)
+    + JDBC Input [Guide](https://github.com/apache/apex-malhar/blob/master/docs/operators/jdbcPollInputOperator.md)
+       and [Java Doc](https://ci.apache.org/projects/apex-malhar/apex-malhar-javadoc-release-3.6/com/datatorrent/lib/db/jdbc/JdbcPollInputOperator.html)
+    + JMS Input [Guide](http://apex.apache.org/docs/malhar/operators/jmsInputOperator/)
+      and [Java Doc](https://ci.apache.org/projects/apex-malhar/apex-malhar-javadoc-release-3.6/com/datatorrent/lib/io/jms/JMSStringInputOperator.html)
+
+- Process
+    + Block Reader [Guide](http://apex.apache.org/docs/malhar/operators/block_reader/)
+      and [Java Doc](https://ci.apache.org/projects/apex-malhar/apex-malhar-javadoc-release-3.6/com/datatorrent/contrib/parser/AbstractBlockReader.html)
+    + CSV Parser [Guide](http://apex.apache.org/docs/malhar/operators/csvParserOperator/)
+      and [Java Doc](https://ci.apache.org/projects/apex-malhar/apex-malhar-javadoc-release-3.6/com/datatorrent/contrib/parser/CsvParser.html)
+    + JSON Parser [Guide](http://apex.apache.org/docs/malhar/operators/jsonParser/)
+      and [Java Doc](https://ci.apache.org/projects/apex-malhar/apex-malhar-javadoc-release-3.6/com/datatorrent/contrib/parser/JsonParser.html)
+    + JSON Formatter  [Guide](http://apex.apache.org/docs/malhar/operators/jsonFormatter/)
+      and [Java Doc](https://ci.apache.org/projects/apex-malhar/apex-malhar-javadoc-release-3.6/com/datatorrent/lib/formatter/JsonFormatter.html)
+    + Deduper  [Guide](http://apex.apache.org/docs/malhar/operators/deduper/)
+      and [Java Doc](https://ci.apache.org/projects/apex-malhar/apex-malhar-javadoc-release-3.6/org/apache/apex/malhar/lib/dedup/AbstractDeduper.html)
+    + Enrich [Guide](http://apex.apache.org/docs/malhar/operators/enricher/)
+      and [Java Doc](https://ci.apache.org/projects/apex-malhar/apex-malhar-javadoc-release-3.6/com/datatorrent/contrib/enrich/AbstractEnricher.html)
+    + Filter  [Guide](http://apex.apache.org/docs/malhar/operators/filter/)
+      and [Java Doc](https://ci.apache.org/projects/apex-malhar/apex-malhar-javadoc-release-3.6/com/datatorrent/lib/filter/FilterOperator.html)
+    + Transform  [Guide](http://apex.apache.org/docs/malhar/operators/transform/)
+      and [Java Doc](https://ci.apache.org/projects/apex-malhar/apex-malhar-javadoc-release-3.6/com/datatorrent/lib/filter/TransformOperator.html)
+
+- Output
+    + HDFS Output [Guide](http://apex.apache.org/docs/malhar/operators/file_output)
+      and [Java Doc](https://ci.apache.org/projects/apex-malhar/apex-malhar-javadoc-release-3.6/com/datatorrent/lib/io/fs/AbstractFileOutputOperator.html)
+    + JMS Output [Guide](http://apex.apache.org/docs/malhar/operators/jmsMultiPortOutputOperator/)
+      and [Java Doc](https://ci.apache.org/projects/apex-malhar/apex-malhar-javadoc-release-3.6/com/datatorrent/lib/io/jms/JMSMultiPortOutputOperator.html)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ pages:
 - Development:
     - Creating Applications: create.md
     - "Beginner's Guide": beginner.md
+    - Videos: demo_videos.md
     - Tutorials:
         - Top N Words:
             - Introduction: tutorials/topnwords.md
@@ -32,6 +33,7 @@ pages:
     - Configuration Packages: configuration_packages.md
     - Operators: operator_development.md
     - Library Operators:
+        - List of Operators: library_operators.md
         - Block Reader: operators/block_reader.md
         - Deduper: operators/deduper.md
         - Dimension Computation: operators/dimensions_computation.md


### PR DESCRIPTION
*_INCOMPLETE -- FOR REVIEW ONLY *_
Notes:
1. We need a full list of matured operators along with guides and Java Doc pages for them.
2. We don't have an anchor page for the operator library, so I just created one that has a bulleted list for each of the 3 categories; each item will have a link to the guide and to the javadoc page (a couple of samples are shown).
3. The "Create Apps" tile now mentions "operator library"
4. The Creating Applications section now has a bullet list with relevant links.

@priteshm @sashadt Please take a look.
