### PR TITLE
Add validation to run script

### DIFF
--- a/run
+++ b/run
@@ -473,6 +473,11 @@ function deleteVersion() {
  * creates a symbolic link from one version to another
  */
 function link() {
+  if (argv.docsVersion === argv.targetVersion) {
+    // docs-version and target-verion cannot be the same
+    throw new Error('Cannot link docs-version to itself.')
+  }
+
   initBuildDir();
   copyCustomDirToBuildDir();
 

--- a/run
+++ b/run
@@ -174,7 +174,11 @@ function injectCustomTheme() {
  * Run the mkdocs build command, make sure we build the new contents into the version directory
  */
 function runMkdocsBuildCommand() {
-  var cmd = 'mkdocs build -c -d ' + versionDir;
+  var cmd = 'rm -rf ' + versionDir;
+  log('removing version directory before running build in case it is a symbolic link:', cmd);
+  execSync(cmd);
+
+  cmd = 'mkdocs build -c -d ' + versionDir;
   log('Executing mkdocs build:', cmd);
   execSync(cmd);
 }

--- a/run
+++ b/run
@@ -225,6 +225,15 @@ function updateVersionsJson(mode, version) {
         // version already in array, set property
         json[idx].gitTag = argv.gitTag;
         json[idx].released = argv.released;
+        delete json[idx].link;
+        delete json[idx].targetVersion;
+
+        // update linked versions to have this gitTag if rebuilding existing version
+        _.each(json, function(row) {
+          if (row.targetVersion === json[idx].version) {
+            row.gitTag = json[idx].gitTag;
+          }
+        });
       }
       break;
     case 'link':

--- a/run
+++ b/run
@@ -253,6 +253,7 @@ function updateVersionsJson(mode, version) {
       } else {
         // version already in array, set property
         json[idx].gitTag = json[targetIdx].gitTag;
+        json[idx].targetVersion = json[targetIdx].version;
         json[idx].released = argv.released;
         json[idx].link = true;
       }


### PR DESCRIPTION
Adding the following:

- Remove version directory before running mkdocs build in case it is a symbolic link.
- Delete targetVersion and link properties when rebuilding an existing version.
- Set linked versions' gitTag to the new gitTag of the version being built.
- Set targetVersion on link row.
- Throw exception if docs-version equals target-version on "link" command