### PR TITLE
Fix ambiguous indentation

### DIFF
--- a/docs/custom/readthedocs_dt/css/theme_extra.css
+++ b/docs/custom/readthedocs_dt/css/theme_extra.css
@@ -149,12 +149,14 @@ form .search-query {
     padding-left: 1em;
 }
 
+/*
 .wy-menu-vertical .subnav li.current > a {
     padding-left: 2.42em;
 }
 .wy-menu-vertical .subnav li.current > ul li a {
     padding-left: 3.23em;
 }
+*/
 
 /*
  * Improve inline code blocks within admonitions.
@@ -259,15 +261,37 @@ td, th {
   padding-left: 0;
 }
 
-/* selected - all */
-.wy-menu-vertical li ul.subnav ul.subnav li a {
-  padding-left: 2.42em;
+/* .toctree-l2 : mkdocs does not apply this class, select it using child combinator (>) */
+.wy-menu-vertical li.toctree-l1 > .subnav > li > span.caption-text,
+.wy-menu-vertical li.toctree-l1 > .subnav > li > a {
+  padding-left: 2.42em !important;
 }
 
-/* selected - second level */
-.wy-menu-vertical .subnav li.current > ul li.toctree-l4 a,
-.wy-menu-vertical .subnav li.current > ul li a.toctree-l5 {
+/* .toctree-l3 */
+.wy-menu-vertical li.toctree-l3 a,
+.wy-menu-vertical li a.toctree-l3 {
   padding-left: 3.42em !important;
+  font-size: 86%;
+}
+
+/* .toctree-l4 */
+.wy-menu-vertical li.toctree-l4 a,
+.wy-menu-vertical li a.toctree-l4 {
+  padding-left: 4.42em !important;
+  font-size: 83%;
+}
+
+/* .toctree-l5 */
+.wy-menu-vertical li.toctree-l5 a,
+.wy-menu-vertical li a.toctree-l5 {
+  padding-left: 5.42em !important;
+  font-size: 83%;
+}
+
+/* extend right padding for more space before breaking */
+.wy-menu-vertical .subnav a,
+.wy-menu-vertical li a {
+  padding-right: 1.5em !important;
 }
 
 .wy-menu-vertical .subnav li.current span.caption-text {

--- a/docs/custom/readthedocs_dt/css/theme_extra.css
+++ b/docs/custom/readthedocs_dt/css/theme_extra.css
@@ -264,25 +264,25 @@ td, th {
 /* .toctree-l2 : mkdocs does not apply this class, select it using child combinator (>) */
 .wy-menu-vertical li.toctree-l1 > .subnav > li > span.caption-text,
 .wy-menu-vertical li.toctree-l1 > .subnav > li > a {
-  padding-left: 2.42em !important;
+  padding-left: 3em !important;
 }
 
 /* .toctree-l3 */
 .wy-menu-vertical li.toctree-l3 a,
 .wy-menu-vertical li a.toctree-l3 {
-  padding-left: 3.42em !important;
+  padding-left: 4.5em !important;
 }
 
 /* .toctree-l4 */
 .wy-menu-vertical li.toctree-l4 a,
 .wy-menu-vertical li a.toctree-l4 {
-  padding-left: 4.42em !important;
+  padding-left: 6em !important;
 }
 
 /* .toctree-l5 */
 .wy-menu-vertical li.toctree-l5 a,
 .wy-menu-vertical li a.toctree-l5 {
-  padding-left: 5.42em !important;
+  padding-left: 6em !important;
 }
 
 /* extend right padding for more space before breaking */

--- a/docs/custom/readthedocs_dt/css/theme_extra.css
+++ b/docs/custom/readthedocs_dt/css/theme_extra.css
@@ -271,21 +271,18 @@ td, th {
 .wy-menu-vertical li.toctree-l3 a,
 .wy-menu-vertical li a.toctree-l3 {
   padding-left: 3.42em !important;
-  font-size: 86%;
 }
 
 /* .toctree-l4 */
 .wy-menu-vertical li.toctree-l4 a,
 .wy-menu-vertical li a.toctree-l4 {
   padding-left: 4.42em !important;
-  font-size: 83%;
 }
 
 /* .toctree-l5 */
 .wy-menu-vertical li.toctree-l5 a,
 .wy-menu-vertical li a.toctree-l5 {
   padding-left: 5.42em !important;
-  font-size: 83%;
 }
 
 /* extend right padding for more space before breaking */


### PR DESCRIPTION
Indentation in the table of contents (sidenav) did not properly show hierarchy.

For example, look at the structure for mkdocs.yml, especially the Development section.

Old:
<img width="353" alt="screen shot 2018-02-26 at 6 41 33 pm" src="https://user-images.githubusercontent.com/2942493/36707832-dd877b6e-1b24-11e8-8f99-49242d481200.png">

New:
<img width="311" alt="screen shot 2018-02-26 at 6 42 22 pm" src="https://user-images.githubusercontent.com/2942493/36707840-e6f4659a-1b24-11e8-877a-2308d9df1884.png">

